### PR TITLE
Agenda for Core-Protocol Working Group June 27, 2024

### DIFF
--- a/core_protocol_working_group/meetings/2024-06-27.md
+++ b/core_protocol_working_group/meetings/2024-06-27.md
@@ -1,0 +1,36 @@
+# Meeting 04 - Core Protocol Working Group
+
+**Date**: June 27, 2024 (Thursday), 10-11am PT (17-18:00 UTC)
+
+## Agenda
+1. Tagging code changes that need an HCU
+2. ???
+
+:pencil: :point_right: Anyone can **add agenda topics** by creating a pull request on this file and extending the list above.
+
+
+**Attendees:**
+
+tbd
+
+## Meeting Content
+
+### 1. Tagging code changes that need an HCU
+
+**Context:** During our [Retro on execution fork](https://www.notion.so/flowfoundation/Retro-on-execution-fork-01504b970441477ebfc0174d14dcb269?pvs=4)
+we identified that a breaking change on the deployment branch `v0.33` was the root cause for the execution fork. 
+
+
+
+
+### 2. xyz
+
+## Key Outcomes
+
+### 1. abc
+### 2. xyz
+
+
+### Links and further reading
+- Meeting Transcript: [2024-06-27_transcript.md](./2024-04-25_transcript.md)
+- Video Recoding: [Flow Core Protocol Working Group 2024-06-27](https://drive.google.com/file/d/1ziNUBz3iNrYG1wun-Mt2kiEWYbsS9IDE/view)


### PR DESCRIPTION
So far, the only topic we have is from Vishal:
> this came from the recent retrospective we ran on the execution node forks.
> * How do we deal with tagging of code changes that need an HCU